### PR TITLE
First pass at linking: "call" for c functions now uses relative offse…

### DIFF
--- a/examples/fibonacci.cpp
+++ b/examples/fibonacci.cpp
@@ -18,7 +18,6 @@ int main()
     jitbox::ValueType int_type = jitbox::ValueType::i32;
     jitbox::Function* func = module.new_function("fibonacci", int_type);
     jitbox::Value* x = func->new_param("x", jitbox::ValueType::i32);
-    jitbox::Value* return_value = func->get_return_value();
 
     const jitbox::Value* one = func->new_constant(int_type, 1);
     const jitbox::Value* two = func->new_constant(int_type, 2);

--- a/examples/helloworld.cpp
+++ b/examples/helloworld.cpp
@@ -18,6 +18,8 @@ int main()
 
     jitbox::Module module = jitbox::Module("helloworld");
 
+    // module.set_option(jitbox::JitOption::DUMP_ASM, true);
+
     jitbox::ValueType return_type = jitbox::ValueType::none;
     jitbox::Function* func = module.new_function("hello", return_type);
     jitbox::Value* str = func->new_param("str", jitbox::ValueType::pointer);

--- a/jitbox/src/codegen.h
+++ b/jitbox/src/codegen.h
@@ -1,6 +1,11 @@
 #pragma once
+#include <unistd.h>
 #include "coretypes.h"
 #include "storagealloc.h"
+
+#ifndef MAP_32BIT
+#define MAP_32BIT 0
+#endif
 
 namespace jitbox
 {
@@ -9,7 +14,8 @@ class CodeGenerator
 {
 public:
     CodeGenerator(bool dump_asm)
-        : m_mem(nullptr), m_page_count(0), m_dump_asm(dump_asm)
+        : m_mem(nullptr), m_page_count(0),
+          m_dump_asm(dump_asm), PAGE_SIZE(sysconf(_SC_PAGESIZE))
     {
     }
 
@@ -22,12 +28,36 @@ public:
     void finalize()
     {
         m_page_count = 1 + (m_code.size()/PAGE_SIZE);
-        m_mem = (u8*)mmap(0, PAGE_SIZE * m_page_count, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        m_mem = (u8*)mmap(0, PAGE_SIZE * m_page_count, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0);
         memcpy(m_mem, &m_code[0], m_code.size());
+
+        // link
+        for( auto patch_loc : m_addresses_to_patch )
+        {
+            u8* patch_address = m_mem + patch_loc;
+            // target address stored, just need relative offset from this.
+            // (int*)patch_address points to location in m_mem of function
+            //   address operand (under assumption loaded into lower 32bits).
+            // *(int*)patch_address loads this stored address.
+            // (size_t) cast to expand to 64bit address (to avoid warning).
+            // (u8*) to treat this address as a pointer.
+            u8* target_address = (u8*)(size_t)*((int*)patch_address);
+            // patch_address + 4 to account for address operand
+            // (call expects offset from address after instruction and operands)
+            int call_offset = (int)(target_address - (patch_address + 4));
+            *((int*)patch_address) = (int)call_offset;
+        }
+
+        // mark as executable and read-only
         mprotect(m_mem, PAGE_SIZE * m_page_count, PROT_READ | PROT_EXEC);
     }
 
     // return index of next instruction
+    size_t get_offset()
+    {
+        return m_code.size();
+    }
+
     size_t get_label_offset(std::string label)
     {
         if(m_dump_asm)
@@ -57,7 +87,6 @@ public:
     virtual void mov(Register dest, Register src) = 0;
     virtual void mov(Register reg, void* address) = 0;
     virtual void mov(Register reg, i32 value) = 0;
-    virtual void call(Register reg) = 0;
     virtual void call(void* address) = 0;
     virtual Value* add(Value* lhs, Value* rhs) = 0;
     virtual Value* sub(Value* lhs, Value* rhs) = 0;
@@ -77,16 +106,16 @@ protected:
       assert(size > 0);
       for( int i = size - 1; i >= 0; --i )
       {
-        m_code.push_back((u8)(instruction >> i*8));
+          m_code.push_back((u8)(instruction >> i*8));
       }
     }
 
     void EmitValue(u64 value, size_t size)
     {
-      for( size_t i = 0; i < size; ++i )
-      {
-        m_code.push_back((u8)(value >> i*8));
-      }
+        for( size_t i = 0; i < size; ++i )
+        {
+            m_code.push_back((u8)(value >> i*8));
+        }
     }
 
     void EmitAddress(void* _address)
@@ -95,12 +124,15 @@ protected:
         EmitValue(address, 8);
     }
 
+    // until code is moved into its final location, cannot calculate relative
+    //  jumps. so, store addresses to patch during linking
+    std::vector<size_t> m_addresses_to_patch;
     StorageAllocator m_storage_alloc;
     bool m_dump_asm;
 
 private:
     std::vector<u8> m_code;
-    const size_t PAGE_SIZE = 4096;
+    const size_t PAGE_SIZE;
     size_t m_page_count;
     u8* m_mem;
 };

--- a/jitbox/src/x64codegen.h
+++ b/jitbox/src/x64codegen.h
@@ -106,24 +106,14 @@ public:
         EmitAddress(address);
     }
 
-    void call(Register reg)
-    {
-        if(m_dump_asm)
-            std::cout << "  call " << reg2str(reg) << std::endl;
-
-        u64 instr = 0xffd0 + (reg.idx >= 8 ? 0x410000 : 0);
-        size_t byte_count = reg.idx >= 8 ? 3 : 2;
-        u8 offset = reg.idx % 8;
-        EmitInstruction(instr+offset, byte_count);
-    }
-
-    // TODO: this is unecessary once linking is implemented
     void call(void* address)
     {
-        Value* temp = m_storage_alloc.alloc_temp(ValueType::pointer);
-        Register reg = temp->get_register();
-        mov(reg, address);
-        call(reg);
+        if(m_dump_asm)
+            std::cout << "  call " << address << " ; c function" << std::endl;
+
+        EmitInstruction(0xe8, 1);
+        m_addresses_to_patch.push_back(get_offset());
+        EmitValue((u32)(size_t)address, 4);
     }
 
     // TODO: refactor arithmetic ops to remove redundency


### PR DESCRIPTION
…ts patched during linking instead of using a register operand.